### PR TITLE
2 blank lines after class or function definition

### DIFF
--- a/linked_list.py
+++ b/linked_list.py
@@ -65,6 +65,7 @@ class LinkedList:
             self.current.next = self.first
             self.first = self.current
 
+
 ll = LinkedList()
 # print('linkedlist representation')
 # print(ll)


### PR DESCRIPTION
Purpose: cement proper formatting, always lint before merging into master
Testing: CLI linter OK
<img width="689" alt="image" src="https://user-images.githubusercontent.com/25446201/85253699-9b3bfe80-b413-11ea-9d3b-f44250fa286f.png">
